### PR TITLE
Add AsyncLLM RL example

### DIFF
--- a/docs/examples/asyncllm_tool_rl.rst
+++ b/docs/examples/asyncllm_tool_rl.rst
@@ -1,0 +1,30 @@
+AsyncLLM RL Example
+===================
+
+This example demonstrates how to pair ``asyncllm`` with ``vllm`` and the
+``trl`` library for a minimal reinforcement learning loop. Model output is
+parsed for ``<tool:...>`` calls. Each tool is invoked through an API and its
+result is masked before continuing the generation. The tool results are then
+used to compute a reward, which updates the policy via ``PPOTrainer``.
+
+The full script can be found in ``examples/asyncllm_tool_rl.py``. It uses
+``httpx`` for asynchronous HTTP requests and assumes an ``AsyncLLM`` class
+provided by the ``asyncllm`` package::
+
+   async def main() -> None:
+       llm = AsyncLLM(engine="vllm", endpoint="http://localhost:8000")
+       tokenizer = AutoTokenizer.from_pretrained("distilgpt2")
+       model = AutoModelForCausalLM.from_pretrained("distilgpt2")
+       ppo = PPOTrainer(PPOConfig(), model, tokenizer=tokenizer)
+
+       prompt = "Calculate 2+2 using <tool:calculator {\"expression\": \"2+2\"}>."
+       final, tools = await generate_with_tools(llm, prompt)
+       reward = compute_reward(tools)
+       query = tokenizer(prompt, return_tensors="pt").input_ids[0]
+       response = tokenizer(final, return_tensors="pt").input_ids[0]
+       ppo.step([query], [response], [reward])
+
+The ``generate_with_tools`` helper parses tool calls, invokes APIs and masks
+their outputs. Rewards can be customized according to the task. Running
+``examples/run_asyncllm_tool_rl.sh`` trains the model for a few iterations and
+saves it for later use.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,6 +59,7 @@ verl is fast with:
    examples/ppo_code_architecture
    examples/gsm8k_example
    examples/multi_modal_example
+   examples/asyncllm_tool_rl
 
 .. toctree::
    :maxdepth: 1

--- a/examples/asyncllm_tool_rl.py
+++ b/examples/asyncllm_tool_rl.py
@@ -1,0 +1,81 @@
+import asyncio
+import json
+import re
+from typing import Dict, List, Tuple
+
+import httpx
+from asyncllm import AsyncLLM
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from trl import PPOConfig, PPOTrainer
+
+TOOL_PATTERN = re.compile(r"<tool:(\w+)\s*(\{.*?\})?>")
+
+
+async def parse_tool_calls(text: str) -> List[Tuple[str, Dict]]:
+    """Extract tool calls from model output."""
+    calls = []
+    for match in TOOL_PATTERN.finditer(text):
+        name = match.group(1)
+        args_str = match.group(2) or "{}"
+        try:
+            args = json.loads(args_str)
+        except json.JSONDecodeError:
+            args = {}
+        calls.append((name, args))
+    return calls
+
+
+async def call_tool_api(name: str, params: Dict) -> str:
+    """Call an external API asynchronously based on the tool name."""
+    url = f"https://api.example.com/{name}"
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(url, json=params)
+        resp.raise_for_status()
+        return resp.text
+
+
+def compute_reward(tool_outputs: Dict[str, str]) -> float:
+    """Dummy reward: 1 if calculator returns 4."""
+    return float(tool_outputs.get("calculator", "").strip() == "4")
+
+
+async def generate_with_tools(llm: AsyncLLM, prompt: str) -> Tuple[str, Dict[str, str]]:
+    """Run one generation step with tool calls and masking."""
+    first = await llm.acomplete(prompt)
+    first_text = first["choices"][0]["message"]["content"]
+
+    tool_calls = await parse_tool_calls(first_text)
+    tool_outputs = {}
+    for name, params in tool_calls:
+        tool_outputs[name] = await call_tool_api(name, params)
+
+    masked = first_text
+    for i, _ in enumerate(tool_calls):
+        masked += f" <tool_output_{i}>"
+
+    second = await llm.acomplete(prompt + masked)
+    final_text = second["choices"][0]["message"]["content"]
+    return final_text, tool_outputs
+
+
+async def main() -> None:
+    llm = AsyncLLM(engine="vllm", endpoint="http://localhost:8000")
+    tokenizer = AutoTokenizer.from_pretrained("distilgpt2")
+    model = AutoModelForCausalLM.from_pretrained("distilgpt2")
+    ppo = PPOTrainer(PPOConfig(), model, tokenizer=tokenizer)
+
+    prompts = ['Calculate 2+2 using <tool:calculator {"expression": "2+2"}>.']
+
+    for prompt in prompts:
+        final, tools = await generate_with_tools(llm, prompt)
+        reward = compute_reward(tools)
+        query = tokenizer(prompt, return_tensors="pt").input_ids[0]
+        response = tokenizer(final, return_tensors="pt").input_ids[0]
+        ppo.step([query], [response], [reward])
+        print(f"Reward: {reward}, output: {final}")
+
+    ppo.save_pretrained("ppo_model")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/run_asyncllm_tool_rl.sh
+++ b/examples/run_asyncllm_tool_rl.sh
@@ -1,0 +1,3 @@
+set -x
+
+python3 examples/asyncllm_tool_rl.py "$@"


### PR DESCRIPTION
## Summary
- migrate post-processing demo to a reinforcement learning example
- describe RL workflow in new `asyncllm_tool_rl` guide
- provide shell script to run the example

## Testing
- `ruff check examples/asyncllm_tool_rl.py`
- `ruff format examples/asyncllm_tool_rl.py`
